### PR TITLE
Allow custom val dataset

### DIFF
--- a/barusini/constants.py
+++ b/barusini/constants.py
@@ -103,3 +103,4 @@ DEFAULT_REGRESSION_METRIC = rmse
 
 TRAIN_MODE = "train"
 TEST_MODE = "test"
+VALID_MODE = "validation"

--- a/barusini/nn/generic/high_level_model.py
+++ b/barusini/nn/generic/high_level_model.py
@@ -39,7 +39,8 @@ def get_attributes(self, **kwargs):
 
 class HighLevelModel(Serializable):
     model_class = None
-    dataset_class = None
+    train_dataset_class = None
+    val_dataset_class = None
 
     def __init__(
         self,
@@ -145,10 +146,10 @@ class HighLevelModel(Serializable):
         if val is None:
             val = train
 
-        tr_ds = self.dataset_class.from_config(
+        tr_ds = self.train_dataset_class.from_config(
             config_path=ckpt_conf, df=train, mode=TRAIN_MODE
         )
-        val_ds = self.dataset_class.from_config(
+        val_ds = self.val_dataset_class.from_config(
             config_path=ckpt_conf, df=val, mode=TEST_MODE
         )
 

--- a/barusini/nn/generic/loading.py
+++ b/barusini/nn/generic/loading.py
@@ -15,6 +15,10 @@ class Serializable:
 
     @classmethod
     def from_config(cls, config_path, **overrides):  # load unfitted
+        # add reference to original config file to the overrides
+        if "original_config_path" not in overrides:
+            overrides["original_config_path"] = config_path
+
         config = parse_config(config_path, **overrides)
         return cls(**config)
 

--- a/barusini/nn/image/image_model.py
+++ b/barusini/nn/image/image_model.py
@@ -9,7 +9,8 @@ from barusini.nn.image.low_level_model import ImageNet
 
 class ImageModel(HighLevelModel):
     model_class = ImageNet
-    dataset_class = ImageDataset
+    train_dataset_class = ImageDataset
+    val_dataset_class = ImageDataset
 
 
 class ImageScorer(Scorer):

--- a/barusini/nn/image/low_level_model.py
+++ b/barusini/nn/image/low_level_model.py
@@ -25,7 +25,7 @@ class ImageNet(nn.Module, Serializable):
             in_chans=in_channels,
         )
 
-    def forward(self, input_dict):
+    def forward(self, input_dict, mode):
         return {"logits": self.net(input_dict)}
 
     def load_weights(self, pretrained_weights):

--- a/barusini/nn/nlp/data.py
+++ b/barusini/nn/nlp/data.py
@@ -20,12 +20,13 @@ class NLPDataset(Dataset, Serializable):
         self.eps = 1e-6
         self.labels = label
         if self.labels is not None:
-            self.labels = df[self.labels].values
+            if self.labels in df.columns:
+                self.labels = df[self.labels].values
+            else:
+                self.labels = None
 
     def __getitem__(self, idx):
-        inpt = {
-            key: self.tokenized_texts[key][idx] for key in self.tokenized_texts
-        }
+        inpt = {key: self.tokenized_texts[key][idx] for key in self.tokenized_texts}
 
         feature_dict = {
             "idx": torch.tensor(idx).long(),

--- a/barusini/nn/nlp/low_level_model.py
+++ b/barusini/nn/nlp/low_level_model.py
@@ -42,7 +42,7 @@ class NlpNet(nn.Module, Serializable):
         self.load_state_dict(state_dict, strict=True)
         print("weights loaded from", pretrained_weights)
 
-    def forward(self, input_dict):
+    def forward(self, input_dict, mode):
         return self.backbone(**input_dict)
 
     def to_folder(self, folder_path=None):

--- a/barusini/nn/nlp/low_level_model.py
+++ b/barusini/nn/nlp/low_level_model.py
@@ -50,8 +50,18 @@ class NlpNet(nn.Module, Serializable):
 
     @classmethod
     def from_folder(
-        cls, folder_path=None, best=False, pretrained_weights=None, **overrides
+        cls,
+        folder_path=None,
+        best=False,
+        pretrained_weights=None,
+        original_config_path=None,
+        **overrides
     ):
+        if folder_path is None:
+            return cls.from_config(
+                original_config_path, pretrained_weights=pretrained_weights, **overrides
+            )
+
         config_path = Serializable.get_config_path(folder_path)
         if best:
             pretrained_weights = Serializable.find_best_ckpt(folder_path)

--- a/barusini/nn/nlp/nlp_model.py
+++ b/barusini/nn/nlp/nlp_model.py
@@ -9,7 +9,8 @@ from barusini.nn.nlp.low_level_model import NlpNet
 
 class NlpModel(HighLevelModel):
     model_class = NlpNet
-    dataset_class = NLPDataset
+    train_dataset_class = NLPDataset
+    val_dataset_class = NLPDataset
 
     def fit(self, train, val, num_workers=8, gpus=("0",), verbose=True):
         os.environ["TOKENIZERS_PARALLELISM"] = "false"


### PR DESCRIPTION
Custom problems might require custom train/validation datasets and different forward pass behaviour, this PR facilitates that.


#### Example Task
Predict comment toxicity score, then comments will be ranked

#### Train data
Comments and toxicity labels (not score)

#### Validation data
Pairs of comments with info which is worse

#### Issue
We can train on single comment labels, but validation loop requires scoring two comments, ranking them, identifying if the rank is good 1 or not 0


